### PR TITLE
added links to article titles

### DIFF
--- a/src/Components/ArticleCard.jsx
+++ b/src/Components/ArticleCard.jsx
@@ -1,7 +1,10 @@
+import { Link } from "react-router-dom";
 export default function ArticleCard({ article }) {
   return (
     <div>
-      <h3>{article.title}</h3>
+      <h3 className="underline hover:text-sky-700">
+        <Link to={`/article/${article.article_id}`}>{article.title}</Link>
+      </h3>
       <p>{article.topic}</p>
       <img className="size-24" src={article.article_img_url} />
       <p>Created by: {article.author}</p>


### PR DESCRIPTION
Regarding feedback from Jodie, added Link components to my article cards. Users can now just click the title of an article to bring them to that articles page rather than having to type the endpoint in.