### PR TITLE
delete comment by ID

### DIFF
--- a/src/Components/Article/ArticleInfo.jsx
+++ b/src/Components/Article/ArticleInfo.jsx
@@ -124,7 +124,11 @@ export default function ArticleInfo() {
           {comments.map((comment) => {
             return (
               <li key={comment.comment_id} className="border-b-2">
-                <CommentCard comment={comment} />
+                <CommentCard
+                  comment={comment}
+                  currArticle={currArticle}
+                  setComments={setComments}
+                />
               </li>
             );
           })}

--- a/src/Components/Article/CommentCard.jsx
+++ b/src/Components/Article/CommentCard.jsx
@@ -1,9 +1,22 @@
 import { format } from "date-fns";
+import DeleteCommentBtn from "./deleteCommentBtn";
 
-function CommentCard({ comment }) {
+import { UserContext } from "../../context/UserContext";
+import { useContext } from "react";
+
+function CommentCard({ comment, setComments }) {
+  const { user } = useContext(UserContext);
   return (
     <div>
-      <h3 className="text-lg font-semibold mb-2">{comment.author}</h3>
+      <div className="flex flex-row justify-between">
+        <h3 className="text-lg font-semibold mb-2">{comment.author}</h3>
+        {user.username === comment.author ? (
+          <DeleteCommentBtn
+            commentID={comment.comment_id}
+            setComments={setComments}
+          />
+        ) : null}
+      </div>
       <p className="text-gray-600 mb-2">
         <strong>Votes:</strong> {comment.votes}
       </p>

--- a/src/Components/Article/DeleteCommentBtn.jsx
+++ b/src/Components/Article/DeleteCommentBtn.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useState } from "react";
+import { deleteCommentByID } from "../../../utils";
+
+function DeleteCommentBtn({ commentID, setComments }) {
+  const [isError, setIsError] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = () => {
+    setIsError(false);
+    setIsDeleting(true);
+    deleteCommentByID(commentID)
+      .then(() => {
+        setComments((prevComments) => {
+          return prevComments.filter(
+            (comment) => comment.comment_id !== commentID
+          );
+        });
+        setIsDeleting(false);
+      })
+      .catch((err) => {
+        setIsError(true);
+        setIsDeleting(false);
+      });
+  };
+
+  return (
+    <div>
+      {isError && (
+        <p>There was a problem deleting your comment, please try again.</p>
+      )}
+      <button className="bg-red-400 p-2 rounded-md mt-3" onClick={handleDelete}>
+        {isDeleting ? "Deleting.." : "Delete Comment"}
+      </button>
+    </div>
+  );
+}
+
+export default DeleteCommentBtn;

--- a/utils.js
+++ b/utils.js
@@ -28,6 +28,12 @@ export const postCommentByID = (id, body, user) => {
   });
 };
 
+export const deleteCommentByID = (id) => {
+  return api.delete(`/comments/${id}`).then((res) => {
+    return res;
+  });
+};
+
 export const patchArticleVotes = (id, inc) => {
   const voteBody = { inc_votes: inc };
   return api.patch(`/articles/${id}`, voteBody).then((res) => {


### PR DESCRIPTION
# Delete comment by ID
Changes:
- I have passed some props down from my ArticleInfo into my CommentCard component to allow me to filter/delete comments as intended.
- I have introduced a new component called DeleteCommentBtn. This button is only present on comments where the comment username matches the username that is 'logged in' on my app (again, hardcoded at the moment to only ever be 1 user).
- Inside my DeleteCommentBtn component I have some state for errors and 'isdeleting' which acts similar to an isloading state. I will use the comment ID passed as a prop to make an endpoint request to remove it from my DB. If this is successful I will also pessimistically remove it from my comments array to properly render this on my page.